### PR TITLE
minor updates to datadog docs

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Datadog Nozzle for PCF (Beta)
+title: Datadog Nozzle for PCF
 owner: Partners
 ---
 <style>
@@ -14,18 +14,24 @@ owner: Partners
 </style>
 
 This documentation describes the Datadog Nozzle for Pivotal Cloud Foundry (PCF). The Datadog Nozzle
-enables PCF users and administrators to monitor the health and performance of their clusters.
+enables PCF users and administrators to monitor the health and performance of their PCF clusters.
+
+For comprehensive monitoring you will want to also install the [Datadog Agent](https://docs.datadoghq.com/integrations/cloud_foundry/#install-the-datadog-agent-bosh-release) and [BOSH Health Monitor](https://docs.datadoghq.com/integrations/cloud_foundry/#configure-the-datadog-plugin-for-bosh-health-monitor).
 
 ## <a id='overview'></a>Overview
 
-Datadog Nozzle for PCF is a Cloud Foundry component which forwards metrics from the Loggregator Firehose to the Datadog monitoring platform. Any Cloud Foundry deployment can send metrics and events to Datadog. The data helps you track the health and availability of all nodes in the deployment, monitor the jobs they run, collect metrics from the Loggregator Firehose, and more.
+Datadog Nozzle for PCF is a Cloud Foundry component which forwards metrics from the Loggregator Firehose to the Datadog monitoring platform. Any Cloud Foundry deployment can send metrics and events to Datadog. The data helps you track the health and availability of all nodes in the deployment, monitor the jobs they run, collect metrics from the Loggregator Firehose, and more. 
 
 Datadog Nozzle for PCF includes includes the following key features:
 
-* Visualization of cluster level operational metrics.
-* Alerting on PCF cluster and component health.
+* Visualization all cluster level operational metrics and KPIs
+* Alerting on PCF cluster and component health
 * Monitoring of jobs
-* Tracking and reporting on BOSH events.
+* Tracking and reporting on BOSH events
+
+Datadog is a monitoring and analytics platform for cloud-scale infrastructure and applications. Datadog provides full-stack observability by combining infrastructure metrics and events with application performance metrics and end-to-end tracing. With flexible graphs and dashboards, sophisticated alerting, and machine learning functionality for anomaly detection and outlier detection, the platform provides actionable insight into dynamic, modern environments. Datadog features 200+ vendor-supported integrations, with simple configuration and built-in template dashboards.
+
+Additional details about the Datadog integration with Cloud Foundry are avaialble via [Datadog's documentation](https://docs.datadoghq.com/integrations/cloud_foundry/).
 
 ## <a id="snapshot"></a>Product Snapshot
 
@@ -64,9 +70,11 @@ The following table provides version and version-support information about the D
 
 Datadog Nozzle for Cloud Foundry has the following requirements:
 
-+ You must have or create an account on https://www.datadoghq.com before configuring the tile.
++ You must have or create a [Datadog account](https://app.datadoghq.com/signup) before configuring the tile.
 
-+ You must install the Datadog Agent BOSH release and Datadog plugin for BOSH Health Monitor as per Datadog's <a href="https://docs.datadoghq.com/integrations/cloud_foundry/">Cloud Foundry documentation</a>.
++ You must generate a [Datadog API key](https://app.datadoghq.com/account/settings#api).
+
++ You must install the Datadog Agent BOSH release and Datadog plugin for BOSH Health Monitor as per Datadog's [Cloud Foundry documentation](https://docs.datadoghq.com/integrations/cloud_foundry/).
 
 ## <a id="feedback"></a>Feedback
 
@@ -77,6 +85,5 @@ Please provide any bugs, feature requests, or questions to the
 
 Datadog Nozzle for PCF is released under the Apache License 2.0. 
 
-To use Datadog Nozzle for PCF, you need a Datadog API key and account. 
+To use Datadog Nozzle for PCF, you need a [Datadog API](https://app.datadoghq.com/account/settings#api) key and account. 
 If you do not have a Datadog account, [sign up here](https://app.datadoghq.com/account/login?next=%2F).
-

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -5,9 +5,8 @@ owner: Partners
 
 This topic describes how to install and configure Datadog Nozzle for Pivotal Cloud Foundry (PCF).
 
-
-1. Ensure you have installed the <a href="https://docs.datadoghq.com/integrations/cloud_foundry/#install-the-datadog-agent-bosh-release">Datadog Agent BOSH Release</a>
-   and <a href="https://docs.datadoghq.com/integrations/cloud_foundry/#configure-the-datadog-plugin-for-bosh-health-monitor">BOSH Health Monitor</a>.
+1. Ensure you have installed the [Datadog Agent BOSH Release](https://docs.datadoghq.com/integrations/cloud_foundry/#install-the-datadog-agent-bosh-release)
+   and [BOSH Health Monitor](https://docs.datadoghq.com/integrations/cloud_foundry/#configure-the-datadog-plugin-for-bosh-health-monitor).
 
 1. Download the product file for the **Datadog Nozzle for PCF** from Pivotal Network.
 
@@ -18,6 +17,10 @@ This adds the tile to your staging area.
 
 1. Click the newly added **Datadog Nozzle for PCF** title.
 
-1. Click **Save**.
+1. In the **Datadog Config** section enter your [Datadog API key](https://app.datadoghq.com/account/settings#api). Leave the Metrics Prefix and Datadog API URL as is unless directed otherwise by [Datadog Support](https://docs.datadoghq.com/help/).
+
+1. Create a UAA client account for Datadog using the [UAA CLI](https://docs.pivotal.io/pivotalcf/uaa/uaa-user-management.html). The Nozzle will require access to the Loggregator Firehose.
+
+1. In the **Cloud Foundry Settings** section, specify a UAA Client and UAA Secret from the previous step.
 
 1. Return to the Ops Manager Installation Dashboard and click **Apply Changes** to install Datadog Nozzle for PCF tile.


### PR DESCRIPTION
- Expand install docs to link to UAA client instructions.
- Link to Datadog official documentation from more places.
- Link to Datadog API key instructions from more places.
- Minor formating