### PR TITLE
adds docs for a new release

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -44,11 +44,11 @@ The following table provides version and version-support information about the D
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v2.0.1</td>
+        <td>v2.1.0</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>March 15, 2018</td>
+        <td>March 23, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,6 +5,16 @@ owner: Partners
 
 These are release notes for Datadog Nozzle for Pivotal Cloud Foundry (PCF).
 
+##<a id="ver"></a> v2.1.0
+
+**Release Date:** March 15, 2018
+
+Features included in this release:
+
+* Updates the agent to 6.1.0
+* Fixes some metric collection in the Agent
+* Fixes process agent hostnames
+
 ##<a id="ver"></a> v2.0.1
 
 **Release Date:** March 15, 2018


### PR DESCRIPTION
We're releasing 2.1.0 -- to go with Agent 6.1.0