### PR TITLE
Update docs to reflect latest release

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -47,7 +47,7 @@ The following table provides version and version-support information about the D
     </tr>
     <tr>
         <td>Release date</td>
-        <td>December 19, 2019</td>
+        <td>December 20, 2019</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -43,15 +43,15 @@ The following table provides version and version-support information about the D
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>2.15.0</td>
+        <td>3.0.0</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>December 18, 2019</td>
+        <td>December 19, 2019</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>2.15.0</td>
+        <td>3.0.0</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -43,15 +43,15 @@ The following table provides version and version-support information about the D
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>2.14.0</td>
+        <td>2.15.0</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>November 7, 2019</td>
+        <td>December 18, 2019</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>2.14.0</td>
+        <td>2.15.0</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,9 +5,9 @@ owner: Partners
 
 These are release notes for Datadog Cluster Monitoring for Pivotal Platform.
 
-##<a id="ver"></a> v2.15.0
+##<a id="ver"></a> v3.0.0
 
-**Release Date:** December 18, 2019
+**Release Date:** December 19, 2019
 
 Feature included in this release:
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -15,6 +15,9 @@ Feature included in this release:
 [datadog-agent 6.16.0](https://github.com/DataDog/datadog-agent/releases/tag/6.16.0) release in GitHub.
 * Upgrades the Nozzle to version 78. For more information, see the [Nozzle Release Page](https://github.com/DataDog/datadog-firehose-nozzle-release/releases/tag/78) in Github.
 
+**Note:** This tile version no longer supports Pivotal Platform v2.3
+Some Firehose Nozzle configuration options may need updating. Please see the release notes above.
+
 ##<a id="ver"></a> v2.14.0
 
 **Release Date:** November 7, 2019

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -7,7 +7,7 @@ These are release notes for Datadog Cluster Monitoring for Pivotal Platform.
 
 ##<a id="ver"></a> v3.0.0
 
-**Release Date:** December 19, 2019
+**Release Date:** December 20, 2019
 
 Feature included in this release:
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,6 +5,16 @@ owner: Partners
 
 These are release notes for Datadog Cluster Monitoring for Pivotal Platform.
 
+##<a id="ver"></a> v2.15.0
+
+**Release Date:** December 18, 2019
+
+Feature included in this release:
+
+* Upgrades the agent to 6.16.0. For more information, see the
+[datadog-agent 6.16.0](https://github.com/DataDog/datadog-agent/releases/tag/6.16.0) release in GitHub.
+* Upgrades the Nozzle to version 78. For more information, see the [Nozzle Release Page](https://github.com/DataDog/datadog-firehose-nozzle-release/releases/tag/78) in Github.
+
 ##<a id="ver"></a> v2.14.0
 
 **Release Date:** November 7, 2019


### PR DESCRIPTION
Update docs to reflect latest 2.15.0 release of the cluster monitoring tile
https://github.com/DataDog/pcf-datadog-cluster-monitoring/releases/tag/3.0.0